### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Build GIMP/macOS inside CircleCI and MacStadium
 
+| x86_64 Build Stats | arm64 Build Stats |
+| ----------- | ----------- |
+| <p align="center"><a href="https://app.circleci.com/insights/github/GNOME/gimp-macos-build/workflows/build-x86_64?branch=master"><img src="https://dl.circleci.com/insights-snapshot/gh/GNOME/gimp-macos-build/master/build-x86_64/badge.svg" alt="InsightsSnapshot" /></a></p> | <p align="center"><a href="https://dl.circleci.com/insights-snapshot/gh/GNOME/gimp-macos-build/master/build-arm64/badge.svg"><img src="https://dl.circleci.com/insights-snapshot/gh/GNOME/gimp-macos-build/master/build-arm64/badge.svg" alt="InsightsSnapshot" /></a></p> |
+
 This repository contains files related to GIMP/macOS build using CircleCI and some tips that
 could help with local development as well.
 


### PR DESCRIPTION
Add CircleCI build stats widget which shows the Insights metrics for the repo that shows how the `default_workflow` is performing. More info can be found at: https://discuss.circleci.com/t/try-insights-snapshot-in-your-gh-repo/43169/

In this case we're showing build stats for the `build-arm64` and `build-x86_64` workflows.